### PR TITLE
License changed to CERN-OHL-P (Permissive)

### DIFF
--- a/LICENSE-CERN-OHL
+++ b/LICENSE-CERN-OHL
@@ -1,4 +1,4 @@
-CERN Open Hardware Licence Version 2 - Strongly Reciprocal
+CERN Open Hardware Licence Version 2 - Permissive
 
 
 Preamble
@@ -7,11 +7,11 @@ CERN has developed this licence to promote collaboration among
 hardware designers and to provide a legal tool which supports the
 freedom to use, study, modify, share and distribute hardware designs
 and products based on those designs. Version 2 of the CERN Open
-Hardware Licence comes in three variants: CERN-OHL-P (permissive); and
-two reciprocal licences: CERN-OHL-W (weakly reciprocal) and this
-licence, CERN-OHL-S (strongly reciprocal).
+Hardware Licence comes in three variants: this licence, CERN-OHL-P
+(permissive); and two reciprocal licences: CERN-OHL-W (weakly
+reciprocal) and CERN-OHL-S (strongly reciprocal).
 
-The CERN-OHL-S is copyright CERN 2020. Anyone is welcome to use it, in
+The CERN-OHL-P is copyright CERN 2020. Anyone is welcome to use it, in
 unmodified form only.
 
 Use of this Licence does not imply any endorsement by CERN of any
@@ -21,88 +21,39 @@ their development.
 
 1 Definitions
 
-  1.1 'Licence' means this CERN-OHL-S.
+  1.1 'Licence' means this CERN-OHL-P.
 
-  1.2 'Compatible Licence' means
-
-       a) any earlier version of the CERN Open Hardware licence, or
-
-       b) any version of the CERN-OHL-S, or
-
-       c) any licence which permits You to treat the Source to which
-          it applies as licensed under CERN-OHL-S provided that on
-          Conveyance of any such Source, or any associated Product You
-          treat the Source in question as being licensed under
-          CERN-OHL-S.
-
-  1.3 'Source' means information such as design materials or digital
+  1.2 'Source' means information such as design materials or digital
       code which can be applied to Make or test a Product or to
       prepare a Product for use, Conveyance or sale, regardless of its
       medium or how it is expressed. It may include Notices.
 
-  1.4 'Covered Source' means Source that is explicitly made available
+  1.3 'Covered Source' means Source that is explicitly made available
       under this Licence.
 
-  1.5 'Product' means any device, component, work or physical object,
+  1.4 'Product' means any device, component, work or physical object,
       whether in finished or intermediate form, arising from the use,
       application or processing of Covered Source.
 
-  1.6 'Make' means to create or configure something, whether by
+  1.5 'Make' means to create or configure something, whether by
       manufacture, assembly, compiling, loading or applying Covered
       Source or another Product or otherwise.
 
-  1.7 'Available Component' means any part, sub-assembly, library or
-      code which:
+  1.6 'Notice' means copyright, acknowledgement and trademark notices,
+      references to the location of any Notices, modification notices
+      (subsection 3.3(b)) and all notices that refer to this Licence
+      and to the disclaimer of warranties that are included in the
+      Covered Source.
 
-       a) is licensed to You as Complete Source under a Compatible
-          Licence; or
-
-       b) is available, at the time a Product or the Source containing
-          it is first Conveyed, to You and any other prospective
-          licensees
-
-            i) as a physical part with sufficient rights and
-               information (including any configuration and
-               programming files and information about its
-               characteristics and interfaces) to enable it either to
-               be Made itself, or to be sourced and used to Make the
-               Product; or
-           ii) as part of the normal distribution of a tool used to
-               design or Make the Product.
-
-  1.8 'Complete Source' means the set of all Source necessary to Make
-      a Product, in the preferred form for making modifications,
-      including necessary installation and interfacing information
-      both for the Product, and for any included Available Components.
-      If the format is proprietary, it must also be made available in
-      a format (if the proprietary tool can create it) which is
-      viewable with a tool available to potential licensees and
-      licensed under a licence approved by the Free Software
-      Foundation or the Open Source Initiative. Complete Source need
-      not include the Source of any Available Component, provided that
-      You include in the Complete Source sufficient information to
-      enable a recipient to Make or source and use the Available
-      Component to Make the Product.
-
-  1.9 'Source Location' means a location where a Licensor has placed
-      Covered Source, and which that Licensor reasonably believes will
-      remain easily accessible for at least three years for anyone to
-      obtain a digital copy.
-
- 1.10 'Notice' means copyright, acknowledgement and trademark notices,
-      Source Location references, modification notices (subsection
-      3.3(b)) and all notices that refer to this Licence and to the
-      disclaimer of warranties that are included in the Covered
-      Source.
-
- 1.11 'Licensee' or 'You' means any person exercising rights under
+  1.7 'Licensee' or 'You' means any person exercising rights under
       this Licence.
 
- 1.12 'Licensor' means a natural or legal person who creates or
-      modifies Covered Source. A person may be a Licensee and a
-      Licensor at the same time.
+  1.8 'Licensor' means a person who creates Source or modifies Covered
+      Source and subsequently Conveys the resulting Covered Source
+      under the terms and conditions of this Licence. A person may be
+      a Licensee and a Licensor at the same time.
 
- 1.13 'Convey' means to communicate to the public or distribute.
+  1.9 'Convey' means to communicate to the public or distribute.
 
 
 2 Applicability
@@ -127,69 +78,41 @@ their development.
   3.1 You may copy and Convey verbatim copies of Covered Source, in
       any medium, provided You retain all Notices.
 
-  3.2 You may modify Covered Source, other than Notices, provided that
-      You irrevocably undertake to make that modified Covered Source
-      available from a Source Location should You Convey a Product in
-      circumstances where the recipient does not otherwise receive a
-      copy of the modified Covered Source. In each case subsection 3.3
-      shall apply.
+  3.2 You may modify Covered Source, other than Notices.
 
       You may only delete Notices if they are no longer applicable to
       the corresponding Covered Source as modified by You and You may
       add additional Notices applicable to Your modifications.
-      Including Covered Source in a larger work is modifying the
-      Covered Source, and the larger work becomes modified Covered
-      Source.
 
   3.3 You may Convey modified Covered Source (with the effect that You
       shall also become a Licensor) provided that You:
 
-       a) retain Notices as required in subsection 3.2;
+       a) retain Notices as required in subsection 3.2; and
 
        b) add a Notice to the modified Covered Source stating that You
           have modified it, with the date and brief description of how
-          You have modified it;
+          You have modified it.
 
-       c) add a Source Location Notice for the modified Covered Source
-          if You Convey in circumstances where the recipient does not
-          otherwise receive a copy of the modified Covered Source; and
+  3.4 You may Convey Covered Source or modified Covered Source under
+      licence terms which differ from the terms of this Licence
+      provided that You:
 
-       d) license the modified Covered Source under the terms and
-          conditions of this Licence (or, as set out in subsection
-          8.3, a later version, if permitted by the licence of the
-          original Covered Source). Such modified Covered Source must
-          be licensed as a whole, but excluding Available Components
-          contained in it, which remain licensed under their own
-          applicable licences.
+       a) comply at all times with subsection 3.3; and
+
+       b) provide a copy of this Licence to anyone to whom You
+          Convey Covered Source or modified Covered Source.
 
 
 4 Making and Conveying Products
 
-You may Make Products, and/or Convey them, provided that You either
-provide each recipient with a copy of the Complete Source or ensure
-that each recipient is notified of the Source Location of the Complete
-Source. That Complete Source is Covered Source, and You must
-accordingly satisfy Your obligations set out in subsection 3.3. If
-specified in a Notice, the Product must visibly and securely display
-the Source Location on it or its packaging or documentation in the
-manner specified in that Notice.
+You may Make Products, and/or Convey them, provided that You ensure
+that the recipient of the Product has access to any Notices applicable
+to the Product.
 
 
-5 Research and Development
+5 DISCLAIMER AND LIABILITY
 
-You may Convey Covered Source, modified Covered Source or Products to
-a legal entity carrying out development, testing or quality assurance
-work on Your behalf provided that the work is performed on terms which
-prevent the entity from both using the Source or Products for its own
-internal purposes and Conveying the Source or Products or any
-modifications to them to any person other than You. Any modifications
-made by the entity shall be deemed to be made by You pursuant to
-subsection 3.2.
-
-
-6 DISCLAIMER AND LIABILITY
-
-  6.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products
+  5.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products
       are provided 'as is' and any express or implied warranties,
       including, but not limited to, implied warranties of
       merchantability, of satisfactory quality, non-infringement of
@@ -204,7 +127,7 @@ subsection 3.2.
       of this Licence and a condition for the grant of any rights
       granted under this Licence.
 
-  6.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to
+  5.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to
       the maximum extent permitted by law, have no liability for
       direct, indirect, special, incidental, consequential, exemplary,
       punitive or other damages of any character including, without
@@ -220,19 +143,20 @@ subsection 3.2.
       in relation to such use.
 
 
-7 Patents
+6 Patents
 
-  7.1 Subject to the terms and conditions of this Licence, each
+  6.1 Subject to the terms and conditions of this Licence, each
       Licensor hereby grants to You a perpetual, worldwide,
       non-exclusive, no-charge, royalty-free, irrevocable (except as
-      stated in subsections 7.2 and 8.4) patent licence to Make, have
-      Made, use, offer to sell, sell, import, and otherwise transfer
-      the Covered Source and Products, where such licence applies only
-      to those patent claims licensable by such Licensor that are
-      necessarily infringed by exercising rights under the Covered
-      Source as Conveyed by that Licensor.
+      stated in this section 6, or where terminated by the Licensor
+      for cause) patent licence to Make, have Made, use, offer to
+      sell, sell, import, and otherwise transfer the Covered Source
+      and Products, where such licence applies only to those patent
+      claims licensable by such Licensor that are necessarily
+      infringed by exercising rights under the Covered Source as
+      Conveyed by that Licensor.
 
-  7.2 If You institute patent litigation against any entity (including
+  6.2 If You institute patent litigation against any entity (including
       a cross-claim or counterclaim in a lawsuit) alleging that the
       Covered Source or a Product constitutes direct or contributory
       patent infringement, or You seek any declaration that a patent
@@ -241,13 +165,13 @@ subsection 3.2.
       terminate as of the date such process is initiated.
 
 
-8 General
+7 General
 
-  8.1 If any provisions of this Licence are or subsequently become
+  7.1 If any provisions of this Licence are or subsequently become
       invalid or unenforceable for any reason, the remaining
       provisions shall remain effective.
 
-  8.2 You shall not use any of the name (including acronyms and
+  7.2 You shall not use any of the name (including acronyms and
       abbreviations), image, or logo by which the Licensor or CERN is
       known, except where needed to comply with section 3, or where
       the use is otherwise allowed by law. Any such permitted use
@@ -255,7 +179,7 @@ subsection 3.2.
       of endorsement or implication of involvement by the Licensor or
       its personnel.
 
-  8.3 CERN may publish updated versions and variants of this Licence
+  7.3 CERN may publish updated versions and variants of this Licence
       which it considers to be in the spirit of this version, but may
       differ in detail to address new problems or concerns. New
       versions will be published with a unique version number and a
@@ -270,21 +194,6 @@ subsection 3.2.
       may apply this or any later version of CERN-OHL with the same
       variant identifier published by CERN.
 
-  8.4 This Licence shall terminate with immediate effect if You fail
-      to comply with any of its terms and conditions.
-
-  8.5 However, if You cease all breaches of this Licence, then Your
-      Licence from any Licensor is reinstated unless such Licensor has
-      terminated this Licence by giving You, while You remain in
-      breach, a notice specifying the breach and requiring You to cure
-      it within 30 days, and You have failed to come into compliance
-      in all material respects by the end of the 30 day period. Should
-      You repeat the breach after receipt of a cure notice and
-      subsequent reinstatement, this Licence will terminate
-      immediately and permanently. Section 6 shall continue to apply
-      after any termination.
-
-  8.6 This Licence shall not be enforceable except by a Licensor
+  7.4 This Licence shall not be enforceable except by a Licensor
       acting as such, and third party beneficiary rights are
       specifically excluded.
-


### PR DESCRIPTION
License changed from CERN-OHL-S (Strongly Reciprocal)  to CERN-OHL-P (Permissive).

Closes: https://github.com/esp-rs/esp-rust-board/issues/31