### PR TITLE
Fix Pin Swap in README.md "Right Side" table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ The following devices are connected through GPIO:
 | 6          | NC             |         |
 | 7          | NC             |         |
 | 8          | NC             |         |
-| 9          | IO18/USB_D-    | GPIO18  |
-| 10         | IO19/USB_D+    | GPIO19  |
+| 9          | IO19/USB_D-    | GPIO19  |
+| 10         | IO18/USB_D+    | GPIO18  |
 | 11         | IO8/SCL        | GPIO8   |
 | 12         | IO10/SDA       | GPIO10  |
 


### PR DESCRIPTION
GPIO18/GPIO19 are in the wrong order in the table.  They do not match the board diagram (or the silkscreen on board in my hands.)
Note: My boards are version v1.2a 04/22, NOT version v1.3.  See discussion below.